### PR TITLE
Map UI improvements

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,5 +5,5 @@
  * @Last Modified Time:  Tuesday May 5th 2020
  * @Copyright:  (c) Oregon State University 2020
  */
-VUE_APP_ROOT_API=http://localhost:3000
+VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/map
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/src/assets/GeoJSON/eco2go_features.hjson
+++ b/src/assets/GeoJSON/eco2go_features.hjson
@@ -7,34 +7,36 @@
     "geometry":{
       "type":"MultiPoint",
       "coordinates": [
-        [-123.285531, 44.560177], // Magruder Hall
+        [-123.285531, 44.560177], // Magruder Hall.
         [-123.274376, 44.559245], // University Plaza
         [-123.276264, 44.560223], // Int. Living Learning Ccenter
-        [-123.277573, 44.560093], // Bloss
-        [-123.27789,  44.560533], // Arnold
-        [-123.277874, 44.561022], // Finley
-        [-123.276645, 44.561003], // Halsell
-        [-123.272735, 44.562639], // Tebeau
-        [-123.27922, 44.563113],  // Dixon Rec Center
-        [-123.285748, 44.56329],  // Richardson / Peavy Hall
-        [-123.272461, 44.563829], // McNary Dining Area
-        [-123.273485, 44.56397],  // Callahan Hall
+        [-123.277573, 44.560093], // Bloss.
+        [-123.27789,  44.560533], // Arnold.
+        [-123.277874, 44.561022], // Finley.
+        [-123.276645, 44.561003], // Halsell.
+        [-123.272735, 44.562639], // Tebeau.
+        [-123.27922, 44.563113],  // Dixon Rec Center.
+        [-123.285748, 44.56329],  // Richardson / Peavy Hall.
+        [-123.272461, 44.563829], // McNary Dining Area.
+        [-123.273485, 44.56397],  // Callahan Hall.
         [-123.274784, 44.564379], // Outside Kerr Admin.
-        [-123.275996, 44.565426], // Outside Valley Library
-        [-123.274997, 44.566791], // Outside Covell Hall
-        [-123.277863, 44.56475],  // Near SEC
-        [-123.27981,  44.564612],  // South of MU Westwing (Common Hall)
+        [-123.275996, 44.565426], // Outside Valley Library.
+        [-123.274997, 44.566791], // Outside Covell Hall.
+        [-123.277863, 44.56475],  // Near SEC.
+        [-123.27981,  44.564612], // South of MU Westwing (Common Hall).
         [-123.280507, 44.563192], // Outside weatherford hall
-        [-123.281602, 44.563234], // Buxton Hall
-        [-123.281607, 44.563783], // Poling Hall
-        [-123.282814, 44.563672], // Cauthorn Hall
-        [-123.282857, 44.564261], // Hawley Hall
-        [-123.283764, 44.563687], // West Dining Hall
-        [-123.283383, 44.565021], // Sackett Hall
-        [-123.281269, 44.565518], // LInC
-        [-123.282149, 44.566523], // Agriculture & Life Sciences building
-        [-123.28033, 44.566902], // Hallie Ford Center
-        [-123.278088, 44.566894], // East of Kelley Eng. Center
+        [-123.281602, 44.563234], // Buxton Hall.
+        [-123.281607, 44.563783], // Poling Hall.
+        [-123.282814, 44.563672], // Cauthorn Hall.
+        [-123.282857, 44.564261], // Hawley Hall.
+        [-123.283764, 44.563687], // West Dining Hall.
+        [-123.283383, 44.565021], // Sackett Hall.
+        [-123.281269, 44.565518], // LInC.
+        [-123.282149, 44.566523], // Agriculture & Life Sciences building.
+        [-123.28033, 44.566902],  // Hallie Ford Center.
+        [-123.278088, 44.566894], // East of Kelley Eng. Center.
+        [-123.2818, 44.5649],     //Austin hall.
+        [-123.2820, 44.5629]      //Legacy Park 
       ]
     },
     "properties":{

--- a/src/assets/GeoJSON/eco2go_features.hjson
+++ b/src/assets/GeoJSON/eco2go_features.hjson
@@ -1,3 +1,5 @@
+// use google maps for coordinates, more accurate
+
 {
   "type":"FeatureCollection",
   "name": "OSU Eco2Go",
@@ -7,36 +9,68 @@
     "geometry":{
       "type":"MultiPoint",
       "coordinates": [
-        [-123.285531, 44.560177], // Magruder Hall.
-        [-123.274376, 44.559245], // University Plaza
-        [-123.276264, 44.560223], // Int. Living Learning Ccenter
-        [-123.277573, 44.560093], // Bloss.
-        [-123.27789,  44.560533], // Arnold.
-        [-123.277874, 44.561022], // Finley.
-        [-123.276645, 44.561003], // Halsell.
-        [-123.272735, 44.562639], // Tebeau.
+
+        // Inside (UHDS Dining Halls) - https://uhds.oregonstate.edu/menus
+        [-123.27211771275113, 44.564087065169836], // McNary Dining Center (not to be confused with Mcnary Hall)
+        [-123.28357233744809, 44.56396961602317], // Marketplace West Dining Center (not to be confused with West Hall)
+        [-123.27770221063265, 44.560631256734005], // Arnold Dining Center.
+
+        // Inside (UHDS Residence Halls) - https://uhds.oregonstate.edu/housing/halls
+        // Unless specified otherwise (e.g. a specific cafe or restaurant inside a larger building), I placed the eco2go somewhere
+        // in the middle of the building inside.
+
+        [-123.27752952783666, 44.560141809861804], // Bloss.
+        [-123.28159979149916, 44.56438160404067], // Buxton Hall.
+        [-123.27337258948464, 44.56405752355515],  // Callahan Hall.
+        [-123.2827455642011, 44.56369550338441], // Cauthorn Hall.
+        [-123.26988207982659, 44.56479501427478],   // Dixon Lodge
+        [-123.27774067380538, 44.561089039983486], // Finley.
+        [-123.2766267416104, 44.56115336876674], // Halsell.
+        [-123.28273165796209, 44.56440307345514], // Hawley Hall.
+        [-123.2761155874166, 44.56015255501253], // Int. Living Learning Center (ILLC)
+        [-123.27185984943819, 44.56438329965402], // McNary Hall (not to be confused with McNary Dining Area)
+        [-123.28157333593195, 44.56369637600066], // Poling Hall.
+        [-123.28351656366307, 44.56524785636432], // Sackett Hall.
+        [-123.27245992384995, 44.56281604778216], // Tebeau.
+        [-123.2805659257728, 44.56408462284122], // Weatherford Hall.
+        [-123.28405220196905, 44.56355513336444], // West Hall (not to be confused with Marketplace West Dining Center)
+        [-123.27235911175512, 44.563775760822786],  // Wilson Hall (UHDS Residence)
+
+        // Inside (Other) - https://uhds.oregonstate.edu/feature-story/eco2go-food-containers
+        [-123.27900991932363, 44.56499838042203],  // Memorial Union ("Off the Quad" restaurant inside, mezzanine level)
+        [-123.27609947075723, 44.565051068486696],   // Valley Library (inside)
+        [-123.27544495168983, 44.56157869718168],   // Cascade Hall
+        // [-123.28016576724922, 44.56410084342818]  // Weatherford ("Bing's Cafe", inside. Temporarily Closed)
+        [-123.27891250757035, 44.566987194703024],    // KEC (inside, e-cafe)
+
+        // Outside - https://uhds.oregonstate.edu/feature-story/eco2go-food-containers
+        // Refer to link above as well as descriptions below - where the direction outside (e.g. "NW Corner") is not specified, 
+        // I chose an arbitrary spot outside of the building to put the eco2go. That isn't ideal, but is important to distinguish 
+        // inside from outside eco2go's, especially for buildings like Valley Library that have both inside and outside KEC
+
+        [-123.28174008376459, 44.56480836986394],     // Austin hall (SE Corner)
+        [-123.28262384082637, 44.564922629029645], // Austin Hall (West Entrance)
+        [-123.2823685893676, 44.566541238777035], // Agriculture & Life Sciences building.
         [-123.27922, 44.563113],  // Dixon Rec Center.
-        [-123.285748, 44.56329],  // Richardson / Peavy Hall.
-        [-123.272461, 44.563829], // McNary Dining Area.
-        [-123.273485, 44.56397],  // Callahan Hall.
+        [-123.27472444313968, 44.56708226085357], // Covell Hall (Outside)
+        [-123.2817055856986, 44.56558500946664], // LInC.
         [-123.274784, 44.564379], // Outside Kerr Admin.
-        [-123.275996, 44.565426], // Outside Valley Library.
-        [-123.274997, 44.566791], // Outside Covell Hall.
-        [-123.277863, 44.56475],  // Near SEC.
-        [-123.27981,  44.564612], // South of MU Westwing (Common Hall).
-        [-123.280507, 44.563192], // Outside weatherford hall
-        [-123.281602, 44.563234], // Buxton Hall.
-        [-123.281607, 44.563783], // Poling Hall.
-        [-123.282814, 44.563672], // Cauthorn Hall.
-        [-123.282857, 44.564261], // Hawley Hall.
-        [-123.283764, 44.563687], // West Dining Hall.
-        [-123.283383, 44.565021], // Sackett Hall.
-        [-123.281269, 44.565518], // LInC.
-        [-123.282149, 44.566523], // Agriculture & Life Sciences building.
-        [-123.28033, 44.566902],  // Hallie Ford Center.
-        [-123.278088, 44.566894], // East of Kelley Eng. Center.
-        [-123.2818, 44.5649],     //Austin hall.
-        [-123.2820, 44.5629]      //Legacy Park 
+        [-123.2827952937462, 44.56237224951695],      // Legacy Park Pavillion
+        [-123.2779370228369, 44.56492643833105],  // SEC Plaza
+        [-123.275996, 44.565426], // Outside Valley Library
+        [-123.28582727474159, 44.56317263241984],  // Richardson Hall (South Entrance)
+        [-123.28482215383578, 44.56059664592913], // Magruder Hall. (East Entrance)
+        [-123.27255303942077, 44.562653479297396],  // Tebeau (South Entrance)
+        [-123.28007441873905, 44.56671156844731],  // 26th and Campus Way (Southwest corner)
+        [-123.27794598436508, 44.56685905649879],  // SW Memorial & Campus Way (NW corner)
+
+        // I was unable to find the following locations listed on https://uhds.oregonstate.edu/feature-story/eco2go-food-containers, or on list of UHDS dining hall / residence halls (Or they are valid locations but named confusingly), so I commented these 
+        // below out. They were already added before Feb 6, 2023.
+
+        // [-123.274376, 44.559245], // University Plaza
+        // [-123.27981,  44.564612], // South of MU Westwing (Common Hall).
+        // [-123.28033, 44.566902],  // Hallie Ford Center.
+        // [-123.278088, 44.566894], // East of Kelley Eng. Center.
       ]
     },
     "properties":{

--- a/src/assets/GeoJSON/eco2go_features.hjson
+++ b/src/assets/GeoJSON/eco2go_features.hjson
@@ -1,5 +1,3 @@
-// use google maps for coordinates, more accurate
-
 {
   "type":"FeatureCollection",
   "name": "OSU Eco2Go",
@@ -9,68 +7,34 @@
     "geometry":{
       "type":"MultiPoint",
       "coordinates": [
-
-        // Inside (UHDS Dining Halls) - https://uhds.oregonstate.edu/menus
-        [-123.27211771275113, 44.564087065169836], // McNary Dining Center (not to be confused with Mcnary Hall)
-        [-123.28357233744809, 44.56396961602317], // Marketplace West Dining Center (not to be confused with West Hall)
-        [-123.27770221063265, 44.560631256734005], // Arnold Dining Center.
-
-        // Inside (UHDS Residence Halls) - https://uhds.oregonstate.edu/housing/halls
-        // Unless specified otherwise (e.g. a specific cafe or restaurant inside a larger building), I placed the eco2go somewhere
-        // in the middle of the building inside.
-
-        [-123.27752952783666, 44.560141809861804], // Bloss.
-        [-123.28159979149916, 44.56438160404067], // Buxton Hall.
-        [-123.27337258948464, 44.56405752355515],  // Callahan Hall.
-        [-123.2827455642011, 44.56369550338441], // Cauthorn Hall.
-        [-123.26988207982659, 44.56479501427478],   // Dixon Lodge
-        [-123.27774067380538, 44.561089039983486], // Finley.
-        [-123.2766267416104, 44.56115336876674], // Halsell.
-        [-123.28273165796209, 44.56440307345514], // Hawley Hall.
-        [-123.2761155874166, 44.56015255501253], // Int. Living Learning Center (ILLC)
-        [-123.27185984943819, 44.56438329965402], // McNary Hall (not to be confused with McNary Dining Area)
-        [-123.28157333593195, 44.56369637600066], // Poling Hall.
-        [-123.28351656366307, 44.56524785636432], // Sackett Hall.
-        [-123.27245992384995, 44.56281604778216], // Tebeau.
-        [-123.2805659257728, 44.56408462284122], // Weatherford Hall.
-        [-123.28405220196905, 44.56355513336444], // West Hall (not to be confused with Marketplace West Dining Center)
-        [-123.27235911175512, 44.563775760822786],  // Wilson Hall (UHDS Residence)
-
-        // Inside (Other) - https://uhds.oregonstate.edu/feature-story/eco2go-food-containers
-        [-123.27900991932363, 44.56499838042203],  // Memorial Union ("Off the Quad" restaurant inside, mezzanine level)
-        [-123.27609947075723, 44.565051068486696],   // Valley Library (inside)
-        [-123.27544495168983, 44.56157869718168],   // Cascade Hall
-        // [-123.28016576724922, 44.56410084342818]  // Weatherford ("Bing's Cafe", inside. Temporarily Closed)
-        [-123.27891250757035, 44.566987194703024],    // KEC (inside, e-cafe)
-
-        // Outside - https://uhds.oregonstate.edu/feature-story/eco2go-food-containers
-        // Refer to link above as well as descriptions below - where the direction outside (e.g. "NW Corner") is not specified, 
-        // I chose an arbitrary spot outside of the building to put the eco2go. That isn't ideal, but is important to distinguish 
-        // inside from outside eco2go's, especially for buildings like Valley Library that have both inside and outside KEC
-
-        [-123.28174008376459, 44.56480836986394],     // Austin hall (SE Corner)
-        [-123.28262384082637, 44.564922629029645], // Austin Hall (West Entrance)
-        [-123.2823685893676, 44.566541238777035], // Agriculture & Life Sciences building.
-        [-123.27922, 44.563113],  // Dixon Rec Center.
-        [-123.27472444313968, 44.56708226085357], // Covell Hall (Outside)
-        [-123.2817055856986, 44.56558500946664], // LInC.
+        [-123.285531, 44.560177], // Magruder Hall
+        [-123.274376, 44.559245], // University Plaza
+        [-123.276264, 44.560223], // Int. Living Learning Ccenter
+        [-123.277573, 44.560093], // Bloss
+        [-123.27789,  44.560533], // Arnold
+        [-123.277874, 44.561022], // Finley
+        [-123.276645, 44.561003], // Halsell
+        [-123.272735, 44.562639], // Tebeau
+        [-123.27922, 44.563113],  // Dixon Rec Center
+        [-123.285748, 44.56329],  // Richardson / Peavy Hall
+        [-123.272461, 44.563829], // McNary Dining Area
+        [-123.273485, 44.56397],  // Callahan Hall
         [-123.274784, 44.564379], // Outside Kerr Admin.
-        [-123.2827952937462, 44.56237224951695],      // Legacy Park Pavillion
-        [-123.2779370228369, 44.56492643833105],  // SEC Plaza
         [-123.275996, 44.565426], // Outside Valley Library
-        [-123.28582727474159, 44.56317263241984],  // Richardson Hall (South Entrance)
-        [-123.28482215383578, 44.56059664592913], // Magruder Hall. (East Entrance)
-        [-123.27255303942077, 44.562653479297396],  // Tebeau (South Entrance)
-        [-123.28007441873905, 44.56671156844731],  // 26th and Campus Way (Southwest corner)
-        [-123.27794598436508, 44.56685905649879],  // SW Memorial & Campus Way (NW corner)
-
-        // I was unable to find the following locations listed on https://uhds.oregonstate.edu/feature-story/eco2go-food-containers, or on list of UHDS dining hall / residence halls (Or they are valid locations but named confusingly), so I commented these 
-        // below out. They were already added before Feb 6, 2023.
-
-        // [-123.274376, 44.559245], // University Plaza
-        // [-123.27981,  44.564612], // South of MU Westwing (Common Hall).
-        // [-123.28033, 44.566902],  // Hallie Ford Center.
-        // [-123.278088, 44.566894], // East of Kelley Eng. Center.
+        [-123.274997, 44.566791], // Outside Covell Hall
+        [-123.277863, 44.56475],  // Near SEC
+        [-123.27981,  44.564612],  // South of MU Westwing (Common Hall)
+        [-123.280507, 44.563192], // Outside weatherford hall
+        [-123.281602, 44.563234], // Buxton Hall
+        [-123.281607, 44.563783], // Poling Hall
+        [-123.282814, 44.563672], // Cauthorn Hall
+        [-123.282857, 44.564261], // Hawley Hall
+        [-123.283764, 44.563687], // West Dining Hall
+        [-123.283383, 44.565021], // Sackett Hall
+        [-123.281269, 44.565518], // LInC
+        [-123.282149, 44.566523], // Agriculture & Life Sciences building
+        [-123.28033, 44.566902], // Hallie Ford Center
+        [-123.278088, 44.566894], // East of Kelley Eng. Center
       ]
     },
     "properties":{

--- a/src/assets/GeoJSON/green_buildings.hjson
+++ b/src/assets/GeoJSON/green_buildings.hjson
@@ -25,7 +25,7 @@
           "coordinates": [-123.278575, 44.567146]
       },
       "properties":{
-          "name": "Kelly Engineering Center",
+          "name": "Kelley Engineering Center",
           "info":"Kelley was OSU’s first certified LEED Gold building and includes the following features: 16,500 gallon rainwater collection system, modular raised floor system that allows air to circulate eliminating the need for ceiling air ducts, systems designed to use ~50% less electricity and ~70% less water than required, a solar thermal system and much more.",
           "tags":["building"],
           "category":"building",

--- a/src/assets/leaflet-global-override.scss
+++ b/src/assets/leaflet-global-override.scss
@@ -10,7 +10,7 @@
 
 .leaflet-tooltip {
   position: absolute;
-  background: none;
+  background-color: rgba(255, 255, 255, 1.0);
   border: none;
   box-shadow: none;
   color: rgb(98, 98, 98);
@@ -20,6 +20,7 @@
   z-index: 900;
   text-align: center;
   white-space: normal; // wraps text vertically
+  padding: 5px;
 }
 
 .leaflet-popup-tip {

--- a/src/components/map/map.vue
+++ b/src/components/map/map.vue
@@ -63,7 +63,7 @@ export default {
       // Map attributions start
       zoom: 15.5,
       minZoom: 14,
-      center: L.latLng(44.565, -123.2785),
+      center: L.latLng(44.5638, -123.2815),
       url: 'https://api.mapbox.com/styles/v1/jack-woods/cjmi2qpp13u4o2spgb66d07ci/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiamFjay13b29kcyIsImEiOiJjamg2aWpjMnYwMjF0Mnd0ZmFkaWs0YzN0In0.qyiDXCvvSj3O4XvPsSiBkA',
       bounds: null,
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',

--- a/src/store/modules/informative_features.js
+++ b/src/store/modules/informative_features.js
@@ -11,20 +11,20 @@ import ProgramFeatures from '@/assets/GeoJSON/program_features.hjson'
 import GreenBuildings from '@/assets/GeoJSON/green_buildings.hjson'
 import RainwaterFeatures from '@/assets/GeoJSON/rainwater_features.hjson'
 import TransportationFeatures from '@/assets/GeoJSON/transportation_features.hjson'
-// import Eco2GoFeatures from '@/assets/GeoJSON/eco2go_features.hjson'
+import Eco2GoFeatures from '@/assets/GeoJSON/eco2go_features.hjson'
 
 const state = {
   sustainabilityFeatures: {
     ProgramFeatures,
     TransportationFeatures,
     GreenBuildings,
-    RainwaterFeatures
-    // Eco2GoFeatures
+    RainwaterFeatures,
+    Eco2GoFeatures
   },
   visibleCategories: {
     bike: true,
     programs: true,
-    // dining: false,
+    dining: false,
     building: true,
     rain: true
   }

--- a/src/store/modules/informative_features.js
+++ b/src/store/modules/informative_features.js
@@ -24,7 +24,7 @@ const state = {
   visibleCategories: {
     bike: true,
     programs: true,
-    dining: false,
+    dining: true,
     building: true,
     rain: true
   }


### PR DESCRIPTION
- Added reset map button, building tooltip (building names) pop up only when you mouse over them, even when zoomed out.
  - No longer have to zoom in just to see what the building is called.
  - Building names only showing up when you mouse over them prevents the map from looking too cluttered when zoomed out
  - Mimics style of energy-dashboard, keep styling consistent
  
- Added "reset map" button like from energy-dashboard repo, to reset map centering and zoom level on click.

![image](https://user-images.githubusercontent.com/82061589/217167218-21e221a6-1610-4041-8735-49712fd48efa.png)
