### PR TITLE
Fix: Anchor element showing when using the search bar. #45

### DIFF
--- a/src/components/navBar.vue
+++ b/src/components/navBar.vue
@@ -51,7 +51,7 @@
                   <strong>{{ name }}: </strong>
                 </el-header>
                 <el-main class="result">
-                  {{ info }}
+                  <span v-html="info"></span>
                 </el-main>
               </el-container>
             </el-dropdown-item>


### PR DESCRIPTION
### Description
- Ensured the proper rendering of `info` property which had the `hyperlink` in the search dropdown.

### Changes made
Before
```
<el-main class="result">
                  {{ info }}
                </el-main>
```
After
```
<el-main class="result">
                  <span v-html="info"></span>
                </el-main>
```

### Related Issues
- Fixes #45 